### PR TITLE
Allows a second format for URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,4 @@ script:
 services:
   - redis-server
 rvm:
-  - 2.1.0
-  - 2.2.0
+  - 2.1.6

--- a/app/models/missing_resque_configuration_error.rb
+++ b/app/models/missing_resque_configuration_error.rb
@@ -1,0 +1,5 @@
+class MissingResqueConfigurationError < StandardError
+  def initialize(environment_variables,resque_name)
+    super("Couldn't find environment variable for Resque #{resque_name}.  Tried: #{environment_variables.join(',')}")
+  end
+end

--- a/app/models/resque_url.rb
+++ b/app/models/resque_url.rb
@@ -1,0 +1,24 @@
+class ResqueUrl
+  def initialize(resque_name)
+    @resque_name = resque_name
+  end
+
+  def url
+    @url ||= environment_variables.map { |environment_variable|
+      ENV[environment_variable]
+    }.compact.first
+    if @url.nil?
+      raise MissingResqueConfigurationError.new(environment_variables,@resque_name)
+    end
+    @url
+  end
+
+  private
+
+  def environment_variables
+    [
+      "RESQUE_BRAIN_INSTANCES_#{@resque_name}", 
+      "#{@resque_name.gsub(/-/,'_').upcase}_RESQUE_REDIS_URL",
+    ]
+  end
+end

--- a/app/models/resques.rb
+++ b/app/models/resques.rb
@@ -8,17 +8,12 @@ require 'resque/data_store'
 #
 # And then use `RESQUES` to access the configured resques.  
 class Resques
-  class MissingResqueConfigurationError < StandardError
-  end
-
   # Parses the environment, yielding each configured instance to the block
   def self.from_environment
     self.new(String(ENV["RESQUE_BRAIN_INSTANCES"]).split(/\s*,\s*/).map { |instance_name|
-      redis = Redis::Namespace.new(:resque,redis: Redis.new(url: ENV.fetch("RESQUE_BRAIN_INSTANCES_#{instance_name}")))
+      redis = Redis::Namespace.new(:resque,redis: Redis.new(url: ResqueUrl.new(instance_name).url))
       ResqueInstance.new(name: instance_name, resque_data_store: Resque::DataStore.new(redis))
     })
-  rescue KeyError => ex
-    raise MissingResqueConfigurationError,ex.message
   end
 
   def initialize(instances)
@@ -34,4 +29,5 @@ class Resques
   def find(name)
     @instances[name]
   end
+
 end


### PR DESCRIPTION
This is to make it easier to use Resque-Brain with Heroku's addon attachments feature.   Because of how that works, Heroku appends `_URL` to addon urls that are shared.  So, our current convention of append the resque name onto them won't work.

But, we don't want to break backwards compatibility, so we allow both.

- [x] merge
- [ ] deploy on Stitch Fix's Heroku infrastructure
- [ ] Update the wiki