### PR TITLE
Add script to run queue size monitoring 1x/min

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb
+monitor_queue_sizes: bin/monitor_queue_sizes

--- a/bin/monitor_queue_sizes
+++ b/bin/monitor_queue_sizes
@@ -1,8 +1,11 @@
 #/usr/bin/env bash
 
-# Once a minute, emit the number of jobs in each queue to Librato
+# Loop forever, emitting queue sizes to librato then sleeping for the configured
+# number of seconds (default to 60).
+
+RESQUE_BRAIN_MONITOR_QUEUE_WAIT_SECONDS=${RESQUE_BRAIN_MONITOR_QUEUE_WAIT_SECONDS:=60}
 
 while true; do
   bundle exec rake monitor:queue_sizes
-  sleep 60
+  sleep $RESQUE_BRAIN_MONITOR_QUEUE_WAIT_SECONDS
 done

--- a/bin/monitor_queue_sizes
+++ b/bin/monitor_queue_sizes
@@ -1,0 +1,8 @@
+#/usr/bin/env bash
+
+# Once a minute, emit the number of jobs in each queue to Librato
+
+while true; do
+  bundle exec rake monitor:queue_sizes
+  sleep 60
+done


### PR DESCRIPTION
As part of my investigation of our checkout service's performance, I've found a desire to have finer grained metrics around queue size than the heroku-scheduler based default of once per 10 minutes.

The mechanism used here will emit the queue size metrics and then sleep for a configured number of seconds that defaults to 60.  This will avoid the situation describe on the [setup page] (https://github.com/stitchfix/resque-brain/wiki/Set-Up#set-up-monitoring-tasks) on the wiki, where running this rake task from the heroku scheduler could cause instances of the task to overlap.