### PR TITLE
get sizes only for monitoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,4 @@ services:
   - redis-server
 rvm:
   - 2.2.4
-  - 2.1.8
   - 2.3.0

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -45,6 +45,13 @@ class ResqueInstance
     }
   end
 
+  # Return the number of jobs waiting, by queue.  Hash of queue_name => number of jobs waiting
+  def waiting_by_queue
+    Hash[@resque_data_store.queue_names.map { |queue_name|
+      [queue_name,@resque_data_store.queue_size(queue_name)]
+    }]
+  end
+
   # Return all jobs that are currently running as an array of `RunningJob` instances
   def jobs_running
     worker_ids = Array(@resque_data_store.worker_ids)

--- a/lib/monitoring/failed_job_check.rb
+++ b/lib/monitoring/failed_job_check.rb
@@ -5,7 +5,7 @@ module Monitoring
       @resques.all.map { |resque_instance|
         CheckResult.new(resque_name: resque_instance.name,
                         check_name: "resque.failed_jobs",
-                        check_count: resque_instance.jobs_failed.size)
+                        check_count: resque_instance.failed)
       }
     end
   end

--- a/lib/monitoring/queue_size_check.rb
+++ b/lib/monitoring/queue_size_check.rb
@@ -3,12 +3,12 @@ module Monitoring
   class QueueSizeCheck < Monitoring::Checker
     def check!
       @resques.all.map { |resque_instance|
-        resque_instance.jobs_waiting.keys.sort.map { |queue_name|
-          jobs = resque_instance.jobs_waiting[queue_name]
+        waiting_by_queue = resque_instance.waiting_by_queue
+        waiting_by_queue.keys.sort.map { |queue_name|
           CheckResult.new(resque_name: resque_instance.name,
                           scope: queue_name,
                           check_name: "resque.queue_size",
-                          check_count: jobs.size)
+                          check_count: waiting_by_queue[queue_name])
         }
       }.flatten
     end

--- a/test/models/resque_instance_test.rb
+++ b/test/models/resque_instance_test.rb
@@ -127,6 +127,13 @@ class ResqueInstanceTest < MiniTest::Test
     assert_equal 7,create_test_instance.waiting
   end
 
+  def test_waiting_by_queue
+    waiting = create_test_instance.waiting_by_queue
+
+    assert_equal 2,waiting["bar"]
+    assert_equal 5,waiting["foo"]
+  end
+
   def test_retry_job
     resque_data_store = fake_resque_data_store
     instance = create_test_instance(resque_data_store: resque_data_store)


### PR DESCRIPTION
These end up pulling back the entire Resque database just to count things.

This is somewhat urgently needed, so I'm going to merge without review.  Please *do* comment on this and I'll make any needed changes.