### PR TITLE
Force SSL in prod

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,12 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   
+  force_ssl if: :ssl_configured?
+
+  def ssl_configured?
+    Rails.env.production?
+  end
+  
   unless Rails.env.test?
     before_filter :authenticate
   end


### PR DESCRIPTION
This will issue a 301 redirect from HTTP to HTTPS for the app's pages, but allow HTTP serving of  static assets.

https://github.com/stitchfix/eng-platform/issues/144