### PR TITLE
configure rack-timeout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'angular-rails-templates', git: "https://github.com/davetron5000/angular-rai
 gem 'puma'
 gem "foreman"
 gem "cron2english"
+gem "rack-timeout"
 
 gem 'resqutils'
 gem 'resque-retry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rack-timeout (0.4.2)
     rails (4.2.5.2)
       actionmailer (= 4.2.5.2)
       actionpack (= 4.2.5.2)
@@ -230,6 +231,7 @@ DEPENDENCIES
   nokogiri (>= 1.6.7.2)
   poltergeist
   puma
+  rack-timeout
   rails (~> 4.2.5.1)
   rails-html-sanitizer (~> 1.0.3)
   rails_12factor

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,2 @@
+Rack::Timeout.service_timeout = (ENV["RACK_SERVICE_TIMEOUT_SECONDS"] || 10).to_s
+Rack::Timeout.wait_timeout    = (ENV["RACK_WAIT_TIMEOUT_SECONDS"]    || 10).to_s


### PR DESCRIPTION
# Problem

We get timeouts from our infrastructure and not from the app.  This is bad for logging, monitoring, and user experience

# Solution

Add [rack-timeout](https://github.com/heroku/rack-timeout)

