### PR TITLE
Avoid deserializing jobs just for counts

### DIFF
--- a/app/assets/javascripts/controllers/WaitingController.coffee
+++ b/app/assets/javascripts/controllers/WaitingController.coffee
@@ -5,10 +5,10 @@ controllers.controller("WaitingController", [
 
     $scope.refresh = ->
       $scope.loading = true
-      Resques.jobsWaiting( { name: $routeParams.resque },
+      Resques.countJobsWaiting( { name: $routeParams.resque },
         ( (jobs)->
             $scope.jobsWaiting      = jobs
-            $scope.totalJobsWaiting = _.reduce($scope.jobsWaiting, ((acc,waitingInQueue)-> acc + waitingInQueue.jobs.length),0)
+            $scope.totalJobsWaiting = _.reduce($scope.jobsWaiting, ((acc,waitingInQueue)-> acc + waitingInQueue.jobs),0)
             $scope.loading          = false
         ),
         GenericErrorHandling.onFail($scope)

--- a/app/assets/javascripts/services/Resques.coffee
+++ b/app/assets/javascripts/services/Resques.coffee
@@ -50,6 +50,8 @@ services.factory("Resques", [
         ResqueJobs.query({ resqueName: resque.name, jobType: "running" }, success, failure)
       jobsWaiting: (resque,success,failure)->
         ResqueJobs.query({ resqueName: resque.name, jobType: "waiting" }, success, failure)
+      countJobsWaiting: (resque,success,failure)->
+        ResqueJobs.query({ resqueName: resque.name, jobType: "waiting", count_only: true }, success, failure)
       jobsFailed:  (resque,start,count,success,failure)->
         ResqueJobs.query({ resqueName: resque.name, jobType: "failed", count: count, start: start }, success, failure)
     }

--- a/app/assets/javascripts/templates/nav.html
+++ b/app/assets/javascripts/templates/nav.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" ng-if="!resqueSelected" ng-click="viewSummary()" href="">Resque-Brain</a>
+      <a class="navbar-brand" ng-if="!resqueSelected" ng-click="viewSummary()" href="">Resque Brain</a>
       <a class="navbar-brand" ng-if="resqueSelected"  ng-click="viewOverview()"  href="">{{resqueSelected}}</a>
     </div>
 
@@ -21,7 +21,7 @@
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li class="dropdown">
-          <a href="" id="dLabel" data-target="#" aria-haspopup="true" aria-expanded="false" role="button" class="dropdown-toggle" data-toggle="dropdown">Resques <b class="caret"></b></a>
+          <a href="" id="dLabel" data-target="#" aria-haspopup="true" aria-expanded="false" role="button" class="dropdown-toggle" data-toggle="dropdown"><i aria-hidden='true' class="glyphicon glyphicon-wrench"></i> Resques <b class="caret"></b></a>
           <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
             <li><a ng-click="viewSummary()" href="">All</a></li>
             <li class="divider"></li>

--- a/app/assets/javascripts/templates/summary.html
+++ b/app/assets/javascripts/templates/summary.html
@@ -26,13 +26,13 @@
             <td>{{resque.name}}</td>
             <td>{{resque.failed}}</td>
             <td>
-              <a ng-click="viewResque('failed',resque)" title="View Failed Jobs" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
+              <a ng-click="viewResque('failed',resque)" title="View Failed Jobs for {{resque.name}}" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
             </td>
           </tr>
         </tbody>
       </table>
-    </article>
-  </section>
+    </section>
+  </article>
   <article class="col-md-4 col-sm-12 col-xs-12 summary-running">
     <section class="panel" ng-class="{ 'panel-info': totalRunningTooLong == 0, 'panel-warning': totalRunningTooLong != 0 }">
       <header class="panel-heading">
@@ -59,7 +59,7 @@
             </td>
             <td class="hidden-xs">{{resque.runningTooLong}}</td>
             <td>
-              <a ng-click="viewResque('running',resque)" title="View Running Jobs" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
+              <a ng-click="viewResque('running',resque)" title="View Running Jobs for {{resque.name}}" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
             </td>
           </tr>
         </tbody>
@@ -87,7 +87,7 @@
             <td>{{resque.name}}</td>
             <td>{{resque.waiting}}</td>
             <td>
-              <a ng-click="viewResque('waiting',resque)" title="View Waiting Jobs" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
+              <a ng-click="viewResque('waiting',resque)" title="View Waiting Jobs for {{resque.name}}" href="">View <i aria-hidden="true" class="glyphicon glyphicon-chevron-right"></i></a>
             </td>
           </tr>
         </tbody>

--- a/app/assets/javascripts/templates/waiting.html
+++ b/app/assets/javascripts/templates/waiting.html
@@ -13,7 +13,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr class="animate-repeat fade-in" ng-repeat="jobsInQueue in jobsWaiting" ng-class="{'success': jobsInQueue.jobs.length == 0, 'warning': jobsInQueue.jobs.length > 0}">
+          <tr class="animate-repeat fade-in" ng-repeat="jobsInQueue in jobsWaiting" ng-class="{'success': jobsInQueue.jobs == 0, 'warning': jobsInQueue.jobs > 0}">
             <td data-queue-name="{{ jobsInQueue.queue }}">{{ jobsInQueue.queue }}</td>
             <td data-queue-count="{{ jobsInQueue.queue}}">{{ jobsInQueue.jobs }}</td>
           </tr>

--- a/app/assets/javascripts/templates/waiting.html
+++ b/app/assets/javascripts/templates/waiting.html
@@ -14,8 +14,8 @@
         </thead>
         <tbody>
           <tr class="animate-repeat fade-in" ng-repeat="jobsInQueue in jobsWaiting" ng-class="{'success': jobsInQueue.jobs.length == 0, 'warning': jobsInQueue.jobs.length > 0}">
-            <td>{{ jobsInQueue.queue }}</td>
-            <td>{{ jobsInQueue.jobs.length }}</td>
+            <td data-queue-name="{{ jobsInQueue.queue }}">{{ jobsInQueue.queue }}</td>
+            <td data-queue-count="{{ jobsInQueue.queue}}">{{ jobsInQueue.jobs }}</td>
           </tr>
         </tbody>
       </table>

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,4 +1,4 @@
-	/*
+/*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.
  *
@@ -36,8 +36,8 @@
 }
 
 .pre-scroll-horizontal {
-  overflow: auto; 
-  word-wrap: normal; 
+  overflow: auto;
+  word-wrap: normal;
   white-space: pre;
 }
 

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -6,7 +6,11 @@ class JobsController < ApplicationController
   end
 
   def waiting
-    @counts_only = params[:count_only] == 'true'
-    @jobs_waiting_by_queue = resque.jobs_waiting
+    if params[:count_only] == 'true'
+      @jobs_waiting_by_queue = resque.waiting_by_queue
+      render :waiting_counts_only
+    else
+      @jobs_waiting_by_queue = resque.jobs_waiting
+    end
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -6,6 +6,7 @@ class JobsController < ApplicationController
   end
 
   def waiting
+    @counts_only = params[:count_only] == 'true'
     @jobs_waiting_by_queue = resque.jobs_waiting
   end
 end

--- a/app/views/jobs/waiting.json.jbuilder
+++ b/app/views/jobs/waiting.json.jbuilder
@@ -1,5 +1,9 @@
 json.array! @jobs_waiting_by_queue.keys.sort do |queue_name|
   json.queue queue_name
-  json.jobs @jobs_waiting_by_queue[queue_name], partial: 'job', as: :job
+  if @counts_only
+    json.jobs @jobs_waiting_by_queue[queue_name].size
+  else
+    json.jobs @jobs_waiting_by_queue[queue_name], partial: 'job', as: :job
+  end
 end
 

--- a/app/views/jobs/waiting_counts_only.json.jbuilder
+++ b/app/views/jobs/waiting_counts_only.json.jbuilder
@@ -1,5 +1,5 @@
 json.array! @jobs_waiting_by_queue.keys.sort do |queue_name|
   json.queue queue_name
-  json.jobs @jobs_waiting_by_queue[queue_name], partial: 'job', as: :job
+  json.jobs @jobs_waiting_by_queue[queue_name]
 end
 

--- a/spec/javascripts/controllers/WaitingControllerSpec.coffee
+++ b/spec/javascripts/controllers/WaitingControllerSpec.coffee
@@ -5,37 +5,19 @@ describe "WaitingController", ->
 
   jobsWaiting = [
     queue: "mail"
-    jobs: [
-      queue: "mail",
-      payload: {
-        class: "UserWelcomeMailer",
-        args: [ 12345 ]
-      }
-      runtime: "0:0:02"
-      worker: "p9e942asfhjsfg"
-      tooLong: false
-    ]
+    jobs: 3
   ,
     queue: "pdf",
-    jobs: [
-      queue: "pdf",
-      payload: {
-        class: "GeneratePackInMaterialsJob",
-        args: [ 947382, true ]
-      }
-      runtime: "1:34:01"
-      worker: "er0ghq3rdfgsefg"
-      tooLong: true
-    ]
+    jobs: 10
   ]
-    
+
   resqueName = 'test'
 
   setupController = ()->
     inject((Resques, $rootScope, $routeParams, $controller)->
       scope   = $rootScope.$new()
       resques = Resques
-      spyOn(resques,"jobsWaiting").andCallFake( (resque,success,failure)-> success(jobsWaiting) )
+      spyOn(resques,"countJobsWaiting").andCallFake( (resque,success,failure)-> success(jobsWaiting) )
       $routeParams.resque = resqueName
 
       ctrl    = $controller('WaitingController', $scope: scope)
@@ -46,5 +28,5 @@ describe "WaitingController", ->
 
   it 'exposes the list of jobs running', ->
     expect(scope.jobsWaiting).toEqualData(jobsWaiting)
-    expect(scope.totalJobsWaiting).toBe(2)
-    expect(resques.jobsWaiting.mostRecentCall.args[0]).toEqualData({ name: resqueName })
+    expect(scope.totalJobsWaiting).toBe(13)
+    expect(resques.countJobsWaiting.mostRecentCall.args[0]).toEqualData({ name: resqueName })

--- a/spec/javascripts/services/ResquesSpec.coffee
+++ b/spec/javascripts/services/ResquesSpec.coffee
@@ -237,6 +237,38 @@ describe "Resques", ->
       expect(receivedJobs).toBe(null)
       expect(errorResponse).toNotBe(null)
 
+  describe 'countJobsWaiting', ->
+    receivedJobs  = null
+    errorResponse = null
+
+    success = (jobs)         -> receivedJobs = jobs
+    failure = (httpResponse) -> errorResponse = httpResponse
+
+    beforeEach ->
+      receivedJobs  = null
+      errorResponse = null
+
+
+    it 'returns from the backend and calls success', ->
+      byQueue = _.chain(fakeJobs).groupBy("queue").map( (queue,jobs)-> { queue: queue, jobs: jobs.length }).value()
+      httpBackend.expectGET(/\/resques\/foobar\/jobs\/waiting.*count_only=true/).respond(byQueue)
+
+      service.countJobsWaiting({ name: "foobar"},success,failure)
+
+      httpBackend.flush()
+
+      expect(receivedJobs).toEqualData(byQueue)
+      expect(errorResponse).toBe(null)
+
+    it 'returns from the backend and calls failure', ->
+      httpBackend.expectGET(/\/resques\/foobar\/jobs\/waiting.*count_only=true/).respond(500)
+
+      service.countJobsWaiting({ name: "foobar" },success,failure)
+      httpBackend.flush()
+
+      expect(receivedJobs).toBe(null)
+      expect(errorResponse).toNotBe(null)
+
   describe 'jobsFailed', ->
     receivedJobs  = null
     errorResponse = null

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -126,4 +126,20 @@ class JobsControllerTest < ActionController::TestCase
 
 
   end
+
+  test "waiting with just counts" do
+    get :waiting, resque_id: "test1", format: :json, count_only: "true"
+
+    assert_response :success
+
+    result = JSON.parse(response.body)
+
+    assert_equal 2, result.size
+
+    assert_equal 1      , result[0]["jobs"]
+    assert_equal "cache", result[0]["queue"]
+
+    assert_equal 2    , result[1]["jobs"]
+    assert_equal "pdf", result[1]["queue"]
+  end
 end

--- a/test/integration/get_summary_test.rb
+++ b/test/integration/get_summary_test.rb
@@ -74,7 +74,6 @@ class GetSummaryTest < ActionDispatch::IntegrationTest
     click_link "View Waiting Jobs"
     assert page.has_text?("3 Jobs Waiting") , page_assertion_error_message(page)
     assert page.has_text?("localhost")      , page_assertion_error_message(page)
-    puts page.html
     within "[data-queue-name='mail']" do
       assert page.has_text?("mail")      , page_assertion_error_message(page)
     end

--- a/test/integration/get_summary_test.rb
+++ b/test/integration/get_summary_test.rb
@@ -74,6 +74,12 @@ class GetSummaryTest < ActionDispatch::IntegrationTest
     click_link "View Waiting Jobs"
     assert page.has_text?("3 Jobs Waiting") , page_assertion_error_message(page)
     assert page.has_text?("localhost")      , page_assertion_error_message(page)
-    assert page.has_text?("mail")           , page_assertion_error_message(page)
+    puts page.html
+    within "[data-queue-name='mail']" do
+      assert page.has_text?("mail")      , page_assertion_error_message(page)
+    end
+    within "[data-queue-count='mail']" do
+      assert page.has_text?("3")      , page_assertion_error_message(page)
+    end
   end
 end

--- a/test/support/fake_resque_instance.rb
+++ b/test/support/fake_resque_instance.rb
@@ -14,7 +14,7 @@ class FakeResqueInstance
 
   def initialize(attributes)
     @name         = attributes.fetch(:name)
-    @jobs_running = attributes[:jobs_running] || []
+    @jobs_running = attributes[:jobs_running] || {}
     @jobs_waiting = attributes[:jobs_waiting] || []
     @jobs_failed  = attributes[:jobs_failed]  || []
     @workers      = attributes[:workers]      || []
@@ -22,6 +22,10 @@ class FakeResqueInstance
     @retried_jobs = []
     @cleared_jobs = []
     @queued_scheduled_jobs = []
+  end
+  
+  implement! def waiting_by_queue
+    @jobs_waiting.map { |queue,jobs| [queue,jobs.size] }.to_h
   end
 
   implement! def name


### PR DESCRIPTION
# Problem

To render the counts per queue on the waiting page, we fetch all jobs in that resque, deserializing them, then count them per queue, basically throwing out all the job data, which we don't need.  This is super slow

# Solution

Stop doing that and instead just fetch the counts, which is already supported by the backend.