### PR TITLE
Ignore job failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :test, :development do
   gem "teaspoon-jasmine"
   gem "dotenv-rails"
   gem "poltergeist"
+  gem "mocha", require: "mocha/setup"
 end
 
 group :production, :staging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,11 +108,14 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    metaclass (0.0.4)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
+    mocha (0.13.2)
+      metaclass (~> 0.0.1)
     mono_logger (1.1.0)
     multi_json (1.12.1)
     newrelic_rpm (3.17.1.326)
@@ -235,6 +238,7 @@ DEPENDENCIES
   foreman
   jbuilder
   jquery-rails
+  mocha
   newrelic_rpm
   nokogiri (>= 1.6.7.2)
   poltergeist

--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -1,3 +1,10 @@
+require 'monitoring/monitor'
+require 'monitoring/librato_notifier'
+require 'monitoring/failed_job_by_class_check'
+require 'monitoring/failed_job_check'
+require 'monitoring/queue_size_check'
+require 'monitoring/stale_worker_check'
+
 class MonitorJob
 
   def self.perform(checker_name)

--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -8,28 +8,22 @@ require 'monitoring/stale_worker_check'
 class MonitorJob
 
   def self.perform(checker_name)
-    monitor = Monitoring::Monitor.new(
-       checker: checker(checker_name),
-       notifier: notifier(checker_name))
-
-    monitor.monitor!
+    checker,notifier = CHECKS_AND_NOTIFIERS.fetch(checker_name.to_sym).()
+    Monitoring::Monitor.new(checker: checker, notifier: notifier).monitor!
   end
 
-  def self.notifier(name)
-    {
-     failed: ->() { Monitoring::LibratoNotifier.new(unit: "jobs") },
-     failed_by_class: ->() { Monitoring::LibratoNotifier.new(unit: "jobs") },
-     stale_workers: ->() { Monitoring::LibratoNotifier.new(type: :measure, unit: "workers") },
-     queue_sizes: ->() { Monitoring::LibratoNotifier.new(unit: "jobs" )},
-    }[name.to_sym].()
-  end
-
-  def self.checker(name)
-    {
-     failed: ->() { Monitoring::FailedJobCheck.new },
-     failed_by_class: ->() { Monitoring::FailedJobByClassCheck.new },
-     stale_workers: ->() { Monitoring::StaleWorkerCheck.new },
-     queue_sizes: ->() { Monitoring::QueueSizeCheck.new },
-    }[name.to_sym].()
-  end
+  CHECKS_AND_NOTIFIERS = {
+    failed: ->() {
+      [ Monitoring::FailedJobCheck.new,        Monitoring::LibratoNotifier.new(unit: "jobs") ]
+    },
+    failed_by_class: ->() {
+      [ Monitoring::FailedJobByClassCheck.new, Monitoring::LibratoNotifier.new(unit: "jobs") ]
+    },
+    stale_workers: ->() {
+      [ Monitoring::StaleWorkerCheck.new,      Monitoring::LibratoNotifier.new(unit: "workers", type: :measure) ]
+    },
+    queue_sizes: ->() {
+      [ Monitoring::QueueSizeCheck.new,        Monitoring::LibratoNotifier.new(unit: "jobs") ]
+    },
+  }
 end

--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -17,19 +17,19 @@ class MonitorJob
 
   def self.notifier(name)
     {
-     failed: Monitoring::LibratoNotifier.new(unit: "jobs"),
-     failed_by_class: Monitoring::LibratoNotifier.new(unit: "jobs"),
-     stale_workers: Monitoring::LibratoNotifier.new(type: :measure, unit: "workers"),
-     queue_sizes: Monitoring::LibratoNotifier.new(unit: "jobs")
-    }[name.to_sym]
+     failed: ->() { Monitoring::LibratoNotifier.new(unit: "jobs") },
+     failed_by_class: ->() { Monitoring::LibratoNotifier.new(unit: "jobs") },
+     stale_workers: ->() { Monitoring::LibratoNotifier.new(type: :measure, unit: "workers") },
+     queue_sizes: ->() { Monitoring::LibratoNotifier.new(unit: "jobs" )},
+    }[name.to_sym].()
   end
 
   def self.checker(name)
     {
-     failed: Monitoring::FailedJobCheck.new,
-     failed_by_class: Monitoring::FailedJobByClassCheck.new,
-     stale_workers: Monitoring::StaleWorkerCheck.new,
-     queue_sizes: Monitoring::QueueSizeCheck.new
-    }[name.to_sym]
+     failed: ->() { Monitoring::FailedJobCheck.new },
+     failed_by_class: ->() { Monitoring::FailedJobByClassCheck.new },
+     stale_workers: ->() { Monitoring::StaleWorkerCheck.new },
+     queue_sizes: ->() { Monitoring::QueueSizeCheck.new },
+    }[name.to_sym].()
   end
 end

--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -12,7 +12,7 @@ class MonitorJob
     begin
       Monitoring::Monitor.new(checker: checker, notifier: notifier).monitor!
     rescue => ex
-      if error_handling == :ignore_and_log_errors
+      if error_handling.to_sym == :ignore_and_log_errors
         Rails.logger.info("Ignoring #{ex.class} from MonitorJob: #{ex.message}")
       else
         raise ex

--- a/config/scheduler.yml
+++ b/config/scheduler.yml
@@ -2,25 +2,25 @@ monitor_queue_sizes:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
-  args: queue_sizes
+  args: [ queue_sizes, ignore_and_log_errors ]
   description: "Send queue sizes to Librato"
 monitor_failed:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
-  args: failed
+  args: [ failed, ignore_and_log_errors ]
   description: "Send failed job counts to Librato"
 monitor_stale_workers:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
-  args: stale_workers
+  args: [ stale_workers, ignore_and_log_errors ]
   description: "Send stale worker counts to Librato"
 monitor_failed_by_class:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
-  args: failed_by_class
+  args: [ failed_by_class, ignore_and_log_errors ]
   description: "Send failed job counts by class to Librato"
 kill_stale_workers:
   # Every hour on the 8's

--- a/config/scheduler.yml
+++ b/config/scheduler.yml
@@ -3,25 +3,25 @@ monitor_queue_sizes:
   class: "MonitorJob"
   queue: monitor
   args: queue_sizes
-  description: "Send monitoring results to Librato"
+  description: "Send queue sizes to Librato"
 monitor_failed:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
   args: failed
-  description: "Send monitoring results to Librato"
+  description: "Send failed job counts to Librato"
 monitor_stale_workers:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
   args: stale_workers
-  description: "Send monitoring results to Librato"
+  description: "Send stale worker counts to Librato"
 monitor_failed_by_class:
   cron: "* * * * * America/New_York"
   class: "MonitorJob"
   queue: monitor
   args: failed_by_class
-  description: "Send monitoring results to Librato"
+  description: "Send failed job counts by class to Librato"
 kill_stale_workers:
   # Every hour on the 8's
   cron: "8 * * * * America/New_York"

--- a/lib/monitoring/failed_job_by_class_check.rb
+++ b/lib/monitoring/failed_job_by_class_check.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require_relative 'checker'
 module Monitoring
   class FailedJobByClassCheck < Monitoring::Checker
     def check!

--- a/lib/monitoring/failed_job_check.rb
+++ b/lib/monitoring/failed_job_check.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require_relative 'checker'
 module Monitoring
   class FailedJobCheck < Monitoring::Checker
 

--- a/lib/monitoring/librato_notifier.rb
+++ b/lib/monitoring/librato_notifier.rb
@@ -1,3 +1,5 @@
+require_relative 'notifier'
+
 module Monitoring
   class LibratoNotifier < Notifier
     def initialize(logger: Rails.logger, type: :count, unit: "")

--- a/lib/monitoring/queue_size_check.rb
+++ b/lib/monitoring/queue_size_check.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require_relative 'checker'
 module Monitoring
   class QueueSizeCheck < Monitoring::Checker
     def check!

--- a/lib/monitoring/stale_worker_check.rb
+++ b/lib/monitoring/stale_worker_check.rb
@@ -1,4 +1,5 @@
 require_relative "wrapped_exception"
+require_relative 'checker'
 
 module Monitoring
   class StaleWorkerCheck < Monitoring::Checker

--- a/test/jobs/monitor_job_test.rb
+++ b/test/jobs/monitor_job_test.rb
@@ -11,12 +11,8 @@ class MonitorJobTest < MiniTest::Test
   def test_failed
     notifier = mock("Monitoring::LibratoNotifier")
     checker = mock("Monitoring::FailedJobCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
-    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier)
     Monitoring::FailedJobCheck.expects(:new).returns(checker)
-    Monitoring::FailedJobByClassCheck.expects(:new)
-    Monitoring::StaleWorkerCheck.expects(:new)
-    Monitoring::QueueSizeCheck.expects(:new)
 
     monitor = stub
     Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
@@ -27,12 +23,8 @@ class MonitorJobTest < MiniTest::Test
   def test_failed_by_class
     notifier = mock("Monitoring::LibratoNotifier")
     checker = mock("Monitoring::FailedJobByClassCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
-    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
     Monitoring::FailedJobByClassCheck.expects(:new).returns(checker)
-    Monitoring::FailedJobCheck.expects(:new)
-    Monitoring::StaleWorkerCheck.expects(:new)
-    Monitoring::QueueSizeCheck.expects(:new)
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).returns(notifier)
 
     monitor = stub
     Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
@@ -42,12 +34,8 @@ class MonitorJobTest < MiniTest::Test
   def test_stale_workers
     notifier = mock("Monitoring::LibratoNotifier")
     checker = mock("Monitoring::StaleWorkerCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
-    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier)
     Monitoring::StaleWorkerCheck.expects(:new).returns(checker)
-    Monitoring::FailedJobCheck.expects(:new)
-    Monitoring::FailedJobByClassCheck.expects(:new)
-    Monitoring::QueueSizeCheck.expects(:new)
 
     monitor = stub
     Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
@@ -57,11 +45,7 @@ class MonitorJobTest < MiniTest::Test
   def test_queue_sizes
     notifier = mock("Monitoring::LibratoNotifier")
     checker = mock("Monitoring::QueueSizeCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
-    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
-    Monitoring::StaleWorkerCheck.expects(:new)
-    Monitoring::FailedJobCheck.expects(:new)
-    Monitoring::FailedJobByClassCheck.expects(:new)
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier)
     Monitoring::QueueSizeCheck.expects(:new).returns(checker)
 
     monitor = stub

--- a/test/jobs/monitor_job_test.rb
+++ b/test/jobs/monitor_job_test.rb
@@ -1,0 +1,72 @@
+require 'quick_test_helper'
+require 'minitest/autorun'
+require 'mocha/setup'
+rails_require 'jobs/monitor_job'
+
+unless defined? RESQUES
+  RESQUES = []
+end
+class MonitorJobTest < MiniTest::Test
+  include Mocha::API
+  def test_failed
+    notifier = mock("Monitoring::LibratoNotifier")
+    checker = mock("Monitoring::FailedJobCheck")
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::FailedJobCheck.expects(:new).returns(checker)
+    Monitoring::FailedJobByClassCheck.expects(:new)
+    Monitoring::StaleWorkerCheck.expects(:new)
+    Monitoring::QueueSizeCheck.expects(:new)
+
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    monitor.expects(:monitor!)
+
+    MonitorJob.perform(:failed)
+  end
+  def test_failed_by_class
+    notifier = mock("Monitoring::LibratoNotifier")
+    checker = mock("Monitoring::FailedJobByClassCheck")
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::FailedJobByClassCheck.expects(:new).returns(checker)
+    Monitoring::FailedJobCheck.expects(:new)
+    Monitoring::StaleWorkerCheck.expects(:new)
+    Monitoring::QueueSizeCheck.expects(:new)
+
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    monitor.expects(:monitor!)
+    MonitorJob.perform(:failed_by_class)
+  end
+  def test_stale_workers
+    notifier = mock("Monitoring::LibratoNotifier")
+    checker = mock("Monitoring::StaleWorkerCheck")
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::StaleWorkerCheck.expects(:new).returns(checker)
+    Monitoring::FailedJobCheck.expects(:new)
+    Monitoring::FailedJobByClassCheck.expects(:new)
+    Monitoring::QueueSizeCheck.expects(:new)
+
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    monitor.expects(:monitor!)
+    MonitorJob.perform(:stale_workers)
+  end
+  def test_queue_sizes
+    notifier = mock("Monitoring::LibratoNotifier")
+    checker = mock("Monitoring::QueueSizeCheck")
+    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).at_least_once
+    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier).at_least_once
+    Monitoring::StaleWorkerCheck.expects(:new)
+    Monitoring::FailedJobCheck.expects(:new)
+    Monitoring::FailedJobByClassCheck.expects(:new)
+    Monitoring::QueueSizeCheck.expects(:new).returns(checker)
+
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    monitor.expects(:monitor!)
+    MonitorJob.perform(:queue_sizes)
+  end
+end

--- a/test/jobs/monitor_job_test.rb
+++ b/test/jobs/monitor_job_test.rb
@@ -53,4 +53,9 @@ class MonitorJobTest < MiniTest::Test
     monitor.expects(:monitor!)
     MonitorJob.perform(:queue_sizes)
   end
+  def test_unhandled_check_name
+    assert_raises(KeyError) do
+      MonitorJob.perform(:foobar)
+    end
+  end
 end

--- a/test/jobs/monitor_job_test.rb
+++ b/test/jobs/monitor_job_test.rb
@@ -6,56 +6,112 @@ rails_require 'jobs/monitor_job'
 unless defined? RESQUES
   RESQUES = []
 end
+unless defined? Rails
+  Rails = Module.new
+end
+
 class MonitorJobTest < MiniTest::Test
   include Mocha::API
-  def test_failed
-    notifier = mock("Monitoring::LibratoNotifier")
-    checker = mock("Monitoring::FailedJobCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier)
-    Monitoring::FailedJobCheck.expects(:new).returns(checker)
 
+  def teardown
+    mocha_teardown
+  end
+
+  def test_failed
     monitor = stub
-    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier,
+                                           checker: mock_checker(Monitoring::FailedJobCheck)).returns(monitor)
     monitor.expects(:monitor!)
 
     MonitorJob.perform(:failed)
+    mocha_verify
   end
-  def test_failed_by_class
-    notifier = mock("Monitoring::LibratoNotifier")
-    checker = mock("Monitoring::FailedJobByClassCheck")
-    Monitoring::FailedJobByClassCheck.expects(:new).returns(checker)
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier).returns(notifier)
 
+  def test_failed_by_class
     monitor = stub
-    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier,
+                                           checker: mock_checker(Monitoring::FailedJobByClassCheck)).returns(monitor)
     monitor.expects(:monitor!)
     MonitorJob.perform(:failed_by_class)
+    mocha_verify
   end
-  def test_stale_workers
-    notifier = mock("Monitoring::LibratoNotifier")
-    checker = mock("Monitoring::StaleWorkerCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(type: :measure, unit: "workers").returns(notifier)
-    Monitoring::StaleWorkerCheck.expects(:new).returns(checker)
 
+  def test_stale_workers
     monitor = stub
-    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier(type: :measure, unit: "workers"),
+                                           checker: mock_checker(Monitoring::StaleWorkerCheck)).returns(monitor)
     monitor.expects(:monitor!)
     MonitorJob.perform(:stale_workers)
+    mocha_verify
   end
-  def test_queue_sizes
-    notifier = mock("Monitoring::LibratoNotifier")
-    checker = mock("Monitoring::QueueSizeCheck")
-    Monitoring::LibratoNotifier.expects(:new).with(unit: "jobs").returns(notifier)
-    Monitoring::QueueSizeCheck.expects(:new).returns(checker)
 
+  def test_queue_sizes
     monitor = stub
-    Monitoring::Monitor.expects(:new).with(notifier: notifier,checker: checker).returns(monitor)
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier,
+                                           checker: mock_checker(Monitoring::QueueSizeCheck)).returns(monitor)
     monitor.expects(:monitor!)
     MonitorJob.perform(:queue_sizes)
+    mocha_verify
   end
+
   def test_unhandled_check_name
     assert_raises(KeyError) do
       MonitorJob.perform(:foobar)
     end
+    mocha_verify
+  end
+
+  def test_when_check_raises_error_we_raise_it_by_default
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier,
+                                           checker: mock_checker(Monitoring::QueueSizeCheck)).returns(monitor)
+    monitor.expects(:monitor!).raises("OH NOES!")
+
+    exception = assert_raises do
+      MonitorJob.perform(:queue_sizes)
+    end
+    assert_equal "OH NOES!", exception.message
+    mocha_verify
+  end
+
+  def test_when_check_raises_error_we_log_and_ignore_if_requested_to
+    monitor = stub
+    Monitoring::Monitor.expects(:new).with(notifier: mock_notifier,
+                                           checker: mock_checker(Monitoring::QueueSizeCheck)).returns(monitor)
+    monitor.expects(:monitor!).raises("OH NOES!")
+
+    logger = mock("Rails Logger")
+    Rails.expects(:logger).returns(logger)
+    logger.expects(:info).with("Ignoring RuntimeError from MonitorJob: OH NOES!")
+
+    refute_raises do
+      MonitorJob.perform(:queue_sizes, :ignore_and_log_errors)
+    end
+    mocha_verify
+  end
+
+private
+
+  def mock_notifier(unit: "jobs", type: :default)
+    mock("Monitoring::LibratoNotifier").tap { |notifier|
+      klass = Monitoring::LibratoNotifier
+      if type == :default
+        klass.expects(:new).with(unit: unit).returns(notifier)
+      else
+        klass.expects(:new).with(type: type, unit: unit).returns(notifier)
+      end
+    }
+  end
+
+  def mock_checker(klass)
+    mock(klass.name).tap { |checker|
+      klass.expects(:new).returns(checker)
+    }
+  end
+
+  def refute_raises(&block)
+    block.()
+  rescue => ex
+    assert false,"Expected no exception, but got #{ex.message}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
-require 'mocha/mini_test'
-
 
 class ActiveSupport::TestCase
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'mocha/mini_test'
+
 
 class ActiveSupport::TestCase
 end


### PR DESCRIPTION
# Problem

When we cannot connect to Redis, which is frequent with RedisCloud, the monitoring jobs fail.  Since they are run periodically, there's no sense retrying them, so we end up with a lot of grinding.

# Solution

Add option to log and ignore them.

## Addendum

`MonitorJob` had no test coverage, and adding it was tricky because it relies on a lot of global state.  Thus, I sadly had to introduce a mocking library in order to get test coverage.  *With* that coverage, I refactored the class to not create every single checker and notifier every single time, instead only creating what is needed.  This change isn't strictly needed for this, but it allowed the tests to be a lot easier to deal with.