### PR TITLE
remove refresh from the failed page

### DIFF
--- a/app/assets/javascripts/controllers/FailedController.coffee
+++ b/app/assets/javascripts/controllers/FailedController.coffee
@@ -1,7 +1,7 @@
 controllers = angular.module("controllers")
 controllers.controller("FailedController", [
-  "$scope", "$modal", "$routeParams", "$location", "$timeout", "$animate", "IntervalRefresh", "Resques", "GenericErrorHandling", "FailedJobs", "flash",
-  ($scope ,  $modal ,  $routeParams ,  $location ,  $timeout ,  $animate ,  IntervalRefresh ,  Resques ,  GenericErrorHandling ,  FailedJobs ,  flash)->
+  "$scope", "$modal", "$routeParams", "$location", "$timeout", "$animate", "Resques", "GenericErrorHandling", "FailedJobs", "flash",
+  ($scope ,  $modal ,  $routeParams ,  $location ,  $timeout ,  $animate ,  Resques ,  GenericErrorHandling ,  FailedJobs ,  flash)->
 
     DEFAULT_PAGE_SIZE = 10
 
@@ -138,7 +138,5 @@ controllers.controller("FailedController", [
     $scope.currentPage = parseInt($routeParams.page or "1")
 
     $scope.refresh = loadFailedJobs
-    IntervalRefresh($scope.refresh,$scope)
-
-
+    loadFailedJobs()
 ])

--- a/app/assets/javascripts/services/IntervalRefresh.coffee
+++ b/app/assets/javascripts/services/IntervalRefresh.coffee
@@ -3,7 +3,7 @@ services = angular.module('services')
 services.factory("IntervalRefresh", [
   "$interval",
   ($interval)->
-    (refreshFunction,scope,refreshTimeout=30000)->
+    (refreshFunction,scope,refreshTimeout=60000)->
       refreshFunction()
       intervalPromise = $interval(refreshFunction, refreshTimeout)
       scope.$on("$destroy", -> $interval.cancel(intervalPromise))


### PR DESCRIPTION
The failed page is fairly expensive and so this disables auto-refresh on
that page, as it is of less overall value here and ends up hitting the
app more frequently than is useful