### PR TITLE
Call the server only once to refresh all home page data

### DIFF
--- a/app/assets/javascripts/services/Resques.coffee
+++ b/app/assets/javascripts/services/Resques.coffee
@@ -24,14 +24,10 @@ services.factory("Resques", [
       summary = []
       all(
         ( (resques)->
-          promises = _.chain(resques).map( (resque)->
-            get(
-              resque.name,
-              ( (resqueSummary)-> addToSummaryKeepingSorted(summary,resqueSummary) ),
-              ( (httpResponse) -> addToSummaryKeepingSorted(summary,{ name: resque.name, error: "Problem retreiving #{resque.name}"}))
-            ).$promise
-          ).value()
-          $q.all(promises)["finally"]( -> success(summary))
+          _.chain(resques).map( (resque)->
+            addToSummaryKeepingSorted(summary,resque)
+          )
+          success(summary)
         ),
         ( (httpResponse)-> failure(httpResponse) )
       )

--- a/app/assets/javascripts/services/Resques.coffee
+++ b/app/assets/javascripts/services/Resques.coffee
@@ -25,8 +25,8 @@ services.factory("Resques", [
       all(
         ( (resques)->
           _.chain(resques).map( (resque)->
-            addToSummaryKeepingSorted(summary,resque)
-          )
+            addToSummaryKeepingSorted(summary,resque).$promise
+          ).value()
           success(summary)
         ),
         ( (httpResponse)-> failure(httpResponse) )

--- a/app/views/resques/index.json.jbuilder
+++ b/app/views/resques/index.json.jbuilder
@@ -1,3 +1,7 @@
 json.array! @resques do |resque|
-  json.name resque.name
+  json.name           resque.name
+  json.failed         resque.failed
+  json.running        resque.running
+  json.runningTooLong resque.running_too_long
+  json.waiting        resque.waiting
 end


### PR DESCRIPTION
This adds the data that's needed to the objects returned by the resques#index and cuts out the individual calls for each app.... I don't really know angular, so I'm not 100% sure this is a nice change at that level.

I'm also don't know if my change will make `resques#index` super slow in prod. Still investigating.