### PR TITLE
fix circle docker tag

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ deployment:
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker build -t stitchfix/resque-brain:$CIRCLE_SHA1 .
-      - docker tag stitchfix/resque-brain:$CIRCLE_SHA1 stitchfix/goro:latest
+      - docker tag stitchfix/resque-brain:$CIRCLE_SHA1 stitchfix/resque-brain:latest
 
 notify:
   webhooks:


### PR DESCRIPTION
`resque-brain:latest` was being tagged incorrectly as `goro:latest`