### PR TITLE
Use singular resource for overview/failed.

### DIFF
--- a/app/assets/javascripts/controllers/FailedController.coffee
+++ b/app/assets/javascripts/controllers/FailedController.coffee
@@ -15,9 +15,9 @@ controllers.controller("FailedController", [
 
     loadFailedJobs = ->
       $scope.loading = true
-      Resques.summary( (
-        (summary)->
-          $scope.numJobsFailed = (_.find(summary, (oneSummary)-> oneSummary.name == $routeParams.resque) or {}).failed
+      Resques.get($routeParams.resque, (
+        (overview)->
+          $scope.numJobsFailed = overview.failed
           $scope.pages = []
           page = 1
           numPages = Math.ceil($scope.numJobsFailed / $scope.pageSize)
@@ -34,8 +34,7 @@ controllers.controller("FailedController", [
             GenericErrorHandling.onFail($scope)
           )
         ),
-        GenericErrorHandling.onFail($scope),
-        "flush"
+        GenericErrorHandling.onFail($scope)
       )
 
     $scope.loading = true

--- a/app/assets/javascripts/controllers/OverviewController.coffee
+++ b/app/assets/javascripts/controllers/OverviewController.coffee
@@ -6,9 +6,9 @@ controllers.controller("OverviewController", [
     $scope.refresh = ->
       $scope.loading = true
 
-      Resques.summary(
-        ( (summary)->
-          overview = (_.find(summary, (oneSummary)-> oneSummary.name == $routeParams.resque) or {})
+      Resques.get(
+        $routeParams.resque,
+        ( (overview)->
           $scope.monitors = [
             Monitor(
               name: 'failed'
@@ -40,7 +40,6 @@ controllers.controller("OverviewController", [
           $scope.loading = false
         ),
         GenericErrorHandling.onFail($scope),
-        "flush"
       )
 
     IntervalRefresh($scope.refresh,$scope)

--- a/spec/javascripts/controllers/FailedControllerSpec.coffee
+++ b/spec/javascripts/controllers/FailedControllerSpec.coffee
@@ -39,13 +39,6 @@ describe "FailedController", ->
     runningTooLong: 3
     waiting: 123
 
-  wwwResque =
-    name: "admin"
-    failed: 2
-    running: 1
-    runningTooLong: 1
-    waiting: 12
-
   resqueName = 'test'
 
   setupController = (page,pageSize,andAlso)->
@@ -58,7 +51,7 @@ describe "FailedController", ->
       spyOn(resques,"jobsFailed").andCallFake( (resque,start,count,success,failure)->
         success(jobsFailed.slice(start,start + count))
       )
-      spyOn(resques,"summary").andCallFake( (success,failure)-> success([testResque,wwwResque]))
+      spyOn(resques,"get").andCallFake( (resque,success,failure)-> success(testResque))
       modalInstance =
         result:
           then: (f)-> f()


### PR DESCRIPTION
Resque failures (such as network timeouts) should not affect all instances. Currently the **Overview** and **Failed Jobs** pages are not useable when there is any failure from any Resque instance.

Rather than calling `Resques.summary` in these controllers, we can call `Resques.get` which ensures the controllers dealing with a single Resque instance remain functional.