### PR TITLE
Works Better, Quick Fix version

### DIFF
--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -1,4 +1,4 @@
-class ResqueInstance
+jlass ResqueInstance
   attr_reader :name,
               :resque_data_store
 
@@ -24,6 +24,8 @@ class ResqueInstance
   def running
     worker_ids = Array(@resque_data_store.worker_ids)
     return 0 if worker_ids.empty?
+    Rails.logger.info("Checking running count for #{name} : #{resque_data_store}")
+
     workers_map(worker_ids).reject { |_,worker_info| worker_info.nil? }.size
   end
 

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -1,4 +1,4 @@
-jlass ResqueInstance
+class ResqueInstance
   attr_reader :name,
               :resque_data_store
 

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -24,8 +24,6 @@ class ResqueInstance
   def running
     worker_ids = Array(@resque_data_store.worker_ids)
     return 0 if worker_ids.empty?
-    Rails.logger.info("Checking running count for #{name} : #{resque_data_store}")
-
     workers_map(worker_ids).reject { |_,worker_info| worker_info.nil? }.size
   end
 
@@ -172,9 +170,9 @@ private
 
   def workers_map(ids)
     Hash[@resque_data_store.workers_map(ids).map { |id,json| [id,(Resque.decode(json) rescue nil)] }]
-  rescue => e
-    p e
-    []
+  rescue Redis::TimeoutError => e
+    Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
+    {}
   end
 
   class WorkerStartTime

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -73,7 +73,7 @@ class ResqueInstance
     }
   rescue Redis::TimeoutError => e
     Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
-    nil
+    []
   end
 
   # Return a hash of all jobs waiting, where the key is the name of the queue and the value

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -172,6 +172,9 @@ private
 
   def workers_map(ids)
     Hash[@resque_data_store.workers_map(ids).map { |id,json| [id,(Resque.decode(json) rescue nil)] }]
+  rescue => e
+    p e
+    []
   end
 
   class WorkerStartTime

--- a/app/models/resque_instance.rb
+++ b/app/models/resque_instance.rb
@@ -25,6 +25,9 @@ class ResqueInstance
     worker_ids = Array(@resque_data_store.worker_ids)
     return 0 if worker_ids.empty?
     workers_map(worker_ids).reject { |_,worker_info| worker_info.nil? }.size
+  rescue Redis::TimeoutError => e
+    Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
+    nil
   end
 
   # Return the number of running jobs that are running "too long" based on the `:stale_worker_seconds` configuration value
@@ -36,6 +39,9 @@ class ResqueInstance
     }.select { |_,worker_info|
       WorkerStartTime.new(worker_info,@stale_worker_seconds).too_long?
     }.size
+  rescue Redis::TimeoutError => e
+    Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
+    nil
   end
 
   # Return the number of jobs waiting, in all queues
@@ -65,6 +71,9 @@ class ResqueInstance
                    too_long: start_time.too_long?,
                       queue: worker_info["queue"])
     }
+  rescue Redis::TimeoutError => e
+    Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
+    nil
   end
 
   # Return a hash of all jobs waiting, where the key is the name of the queue and the value
@@ -170,9 +179,6 @@ private
 
   def workers_map(ids)
     Hash[@resque_data_store.workers_map(ids).map { |id,json| [id,(Resque.decode(json) rescue nil)] }]
-  rescue Redis::TimeoutError => e
-    Rails.logger.error("Timed out getting worker data for #{name} #{e.inspect}")
-    {}
   end
 
   class WorkerStartTime

--- a/spec/javascripts/controllers/SummaryControllerSpec.coffee
+++ b/spec/javascripts/controllers/SummaryControllerSpec.coffee
@@ -4,8 +4,7 @@ describe "SummaryController", ->
   resques = null
 
   fakeResques = [
-      name: "www"
-    ,
+      name: "www",
       name: "admin"
   ]
 
@@ -17,17 +16,24 @@ describe "SummaryController", ->
     waiting: 123
 
   wwwResque =
-    name: "admin"
+    name: "www"
     failed: 2
     running: 1
     runningTooLong: 1
     waiting: 12
 
+  timedOutResque =
+    name: "timey"
+    failed: null
+    running: null
+    runningTooLong: null
+    waiting: null
+
   setupController = ()->
     inject((Resques, $rootScope, $controller)->
       scope   = $rootScope.$new()
       resques = Resques
-      spyOn(resques,"summary").andCallFake( (success,failure)-> success([adminResque,wwwResque]))
+      spyOn(resques,"summary").andCallFake( (success,failure)-> success([adminResque,wwwResque,timedOutResque]))
 
       ctrl    = $controller('SummaryController', $scope: scope)
     )
@@ -36,7 +42,7 @@ describe "SummaryController", ->
   beforeEach(setupController())
 
   it 'exposes the list of resques', ->
-    expect(scope.allResques).toEqualData([adminResque,wwwResque])
+    expect(scope.allResques).toEqualData([adminResque,wwwResque,timedOutResque])
 
   it 'summarizes the values across all resques', ->
     expect(scope.totalFailed).toBe(14)

--- a/test/controllers/resques_controller_test.rb
+++ b/test/controllers/resques_controller_test.rb
@@ -28,13 +28,13 @@ class ResquesControllerTest < ActionController::TestCase
     assert_equal 2, result.size
   end
 
-  test "a redis connection is timing out, it returns 0 for its running value" do
+  test "a redis connection is timing out, it returns nil for its running value" do
     @resques.all.first.resque_data_store.expects(:workers_map).at_least(1).raises(Redis::TimeoutError)
     get :index, format: :json
     result = JSON.parse(response.body)
     assert_equal result[0]["name"],"Test1"
     assert_equal result[1]["name"],"test2"
-    assert_equal result[1]["running"],0
+    assert_nil result[1]["running"]
     assert_equal 2, result.size
   end
 

--- a/test/controllers/resques_controller_test.rb
+++ b/test/controllers/resques_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'mocha/setup'
 require 'support/fake_resque_data_store'
 
 class ResquesControllerTest < ActionController::TestCase
@@ -23,6 +24,17 @@ class ResquesControllerTest < ActionController::TestCase
     result = JSON.parse(response.body)
     assert_equal result[0]["name"],"Test1"
     assert_equal result[1]["name"],"test2"
+    assert_equal result[1]["running"],4
+    assert_equal 2, result.size
+  end
+
+  test "a redis connection is timing out, it returns 0 for its running value" do
+    @resques.all.first.resque_data_store.expects(:workers_map).at_least(1).raises(Redis::TimeoutError)
+    get :index, format: :json
+    result = JSON.parse(response.body)
+    assert_equal result[0]["name"],"Test1"
+    assert_equal result[1]["name"],"test2"
+    assert_equal result[1]["running"],0
     assert_equal 2, result.size
   end
 


### PR DESCRIPTION
This is the quick version of solving the Redis timeout problem.
This is less than optimal, because the `running` value for the redis in question will appear to be 0 (incorrectly).

I'm going to work on a better solution now that I have my head around it fully and have this level of fix working.