### PR TITLE
derive redises from environment

### DIFF
--- a/app/models/resque_url.rb
+++ b/app/models/resque_url.rb
@@ -1,6 +1,30 @@
 class ResqueUrl
+
+  def self.recognize(env_var_name)
+    upper_name = if env_var_name =~ /RESQUE_BRAIN_INSTANCES_(.*)$/
+                   $1
+                 elsif env_var_name =~ /(^.*)_RESQUE_REDIS_URL$/
+                   $1
+                 elsif env_var_name =~ /(^.*)_REDIS_URL$/
+                   $1
+                 else
+                   nil
+                 end
+    if upper_name
+      self.new(upper_name.gsub(/_/,'-').downcase)
+    else
+      nil
+    end
+  end
+
+  attr_reader :resque_name
+
   def initialize(resque_name)
     @resque_name = resque_name
+  end
+
+  def namespace_env_var
+    @resque_name.upcase.gsub(/-/,'_') + "_NAMESPACE"
   end
 
   def url
@@ -18,6 +42,7 @@ class ResqueUrl
   def environment_variables
     [
       "RESQUE_BRAIN_INSTANCES_#{@resque_name}",
+      "RESQUE_BRAIN_INSTANCES_#{@resque_name.gsub(/-/,'_')}",
       "#{@resque_name.gsub(/-/,'_').upcase}_RESQUE_REDIS_URL",
       "#{@resque_name.gsub(/-/,'_').upcase}_REDIS_URL",
     ]

--- a/test/models/resque_url_test.rb
+++ b/test/models/resque_url_test.rb
@@ -1,0 +1,89 @@
+require 'quick_test_helper'
+require 'minitest/autorun'
+rails_require 'models/resque_url'
+rails_require 'models/missing_resque_configuration_error'
+
+class ResqueUrlTest < MiniTest::Test
+
+  def setup
+    ENV["FOO_BAR_RESQUE_REDIS_URL"] = nil
+    ENV["FOO_BAR_REDIS_URL"] = nil
+    ENV["RESQUE_BRAIN_INSTANCES_foo_bar"] = nil
+    ENV["RESQUE_BRAIN_INSTANCES_foo-bar"] = nil
+  end
+
+  def test_recognize_uses_RESQUE_BRAIN_INSTANCES_
+    resque_url  = ResqueUrl.recognize("RESQUE_BRAIN_INSTANCES_foo-bar")
+    assert_equal "foo-bar", resque_url.resque_name
+  end
+
+  def test_recognize_uses_RESQUE_REDIS_URL
+    resque_url  = ResqueUrl.recognize("FOO_BAR_RESQUE_REDIS_URL")
+    assert_equal "foo-bar", resque_url.resque_name
+  end
+
+  def test_recognize_uses_REDIS_URL
+    resque_url  = ResqueUrl.recognize("FOO_BAR_REDIS_URL")
+    assert_equal "foo-bar", resque_url.resque_name
+  end
+
+  def test_recognize_returns_nil_for_other_env_vars
+    assert_nil ResqueUrl.recognize("SIDEKIQ_URL")
+  end
+
+  def test_namespace_env_var
+    assert_equal "FOO_BAR_NAMESPACE", ResqueUrl.new("foo-bar").namespace_env_var
+  end
+
+  def test_url_uses_RESQUE_BRAIN_INSTANCES_
+    ENV["RESQUE_BRAIN_INSTANCES_foo-bar"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_url_uses_RESQUE_BRAIN_INSTANCES_with_underscore
+    ENV["RESQUE_BRAIN_INSTANCES_foo_bar"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_url_uses_RESQUE_REDIS_URL
+    ENV["FOO_BAR_RESQUE_REDIS_URL"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_url_uses_REDIS_URL
+    ENV["FOO_BAR_REDIS_URL"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_url_favors_RESQUE_BRAIN_INSTANCES_
+    ENV["FOO_BAR_REDIS_URL"] = "some other url"
+    ENV["FOO_BAR_RESQUE_REDIS_URL"] = "some other other url"
+    ENV["RESQUE_BRAIN_INSTANCES_foo-bar"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_url_favors_RESQUE_REDIS_URL
+    ENV["FOO_BAR_REDIS_URL"] = "some other url"
+    ENV["FOO_BAR_RESQUE_REDIS_URL"] = "some url"
+    resque_url  = ResqueUrl.new("foo-bar")
+    assert_equal "some url",resque_url.url
+  end
+
+  def test_missing_url_blows_up
+    resque_url  = ResqueUrl.new("foo-bar")
+    ex = assert_raises(MissingResqueConfigurationError) do
+      url = resque_url.url
+      puts url
+    end
+    assert_match /foo-bar/, ex.message
+    assert_match /FOO_BAR_RESQUE_REDIS_URL/, ex.message
+    assert_match /FOO_BAR_REDIS_URL/, ex.message
+    assert_match /RESQUE_BRAIN_INSTANCES_foo_bar/, ex.message
+    assert_match /RESQUE_BRAIN_INSTANCES_foo-bar/, ex.message
+  end
+end

--- a/test/models/resque_url_test.rb
+++ b/test/models/resque_url_test.rb
@@ -12,6 +12,13 @@ class ResqueUrlTest < MiniTest::Test
     ENV["RESQUE_BRAIN_INSTANCES_foo-bar"] = nil
   end
 
+  def teardown
+    ENV["FOO_BAR_RESQUE_REDIS_URL"] = nil
+    ENV["FOO_BAR_REDIS_URL"] = nil
+    ENV["RESQUE_BRAIN_INSTANCES_foo_bar"] = nil
+    ENV["RESQUE_BRAIN_INSTANCES_foo-bar"] = nil
+  end
+
   def test_recognize_uses_RESQUE_BRAIN_INSTANCES_
     resque_url  = ResqueUrl.recognize("RESQUE_BRAIN_INSTANCES_foo-bar")
     assert_equal "foo-bar", resque_url.resque_name

--- a/test/models/resques_test.rb
+++ b/test/models/resques_test.rb
@@ -95,6 +95,39 @@ class ResquesTest < MiniTest::Test
     assert_equal CachedResqueInstance,resques.find("env2").class
   end
 
+  def test_from_environment_deriving
+    ENV["RESQUE_BRAIN_CACHE_RESQUE_CALLS"] = nil
+    ENV["RESQUE_BRAIN_INSTANCES"] = "DERIVE"
+    ENV["RESQUE_BRAIN_INSTANCES_env1"] = "redis://whatever:supersecret@localhost:1234"
+    ENV["ENV2_RESQUE_REDIS_URL"] = "redis://whatever:megasecret@10.0.0.1:4567"
+    ENV["ENV3_REDIS_URL"] = "redis://whatever:l33secret@10.0.1.1:4568"
+
+    resques = Resques.from_environment
+
+    assert_equal 3, resques.all.size
+    refute_nil resques.find("env1")
+    refute_nil resques.find("env2")
+    refute_nil resques.find("env3")
+
+    redis_namespace = resques.find("env1").resque_data_store.instance_variable_get("@redis")
+    assert       redis_namespace.kind_of?(Redis::Namespace)
+    assert_equal 1234          , redis_namespace.redis.client.port
+    assert_equal "localhost"   , redis_namespace.redis.client.host
+    assert_equal "supersecret" , redis_namespace.redis.client.password
+
+    redis_namespace = resques.find("env2").resque_data_store.instance_variable_get("@redis")
+    assert       redis_namespace.kind_of?(Redis::Namespace)
+    assert_equal 4567          , redis_namespace.redis.client.port
+    assert_equal "10.0.0.1"    , redis_namespace.redis.client.host
+    assert_equal "megasecret"  , redis_namespace.redis.client.password
+
+    redis_namespace = resques.find("env3").resque_data_store.instance_variable_get("@redis")
+    assert       redis_namespace.kind_of?(Redis::Namespace)
+    assert_equal 4568          , redis_namespace.redis.client.port
+    assert_equal "10.0.1.1"    , redis_namespace.redis.client.host
+    assert_equal "l33secret"   , redis_namespace.redis.client.password
+  end
+
   def test_from_environment_missing_config
     ENV["RESQUE_BRAIN_INSTANCES"] = "env1,env2"
     ENV["RESQUE_BRAIN_INSTANCES_env1"] = "redis://localhost:1234"


### PR DESCRIPTION
# Problem

In order to monitor a resque, you have to both set its url in the env and also adjust the value for `RESQUE_BRAIN_INSTANCES`.  This is inconvenient and error-prone.

# Solution

Allow deriving the value from the environment variables by setting `RESQUE_BRAIN_INSTANCES` to the magic string `DERIVE`