### PR TITLE
Add env_management gem and .locals to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ spec/file-upload/stylecard-from-db.jpg
 .env.production
 prod_env
 _site
+.env.development.local
+.env.test.local

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ group :test, :development do
   gem "capybara"
   gem "selenium-webdriver"
   gem "teaspoon-jasmine"
-  gem "dotenv-rails"
   gem "poltergeist"
   gem "mocha"
 end
@@ -41,3 +40,6 @@ end
 gem 'nokogiri', '>= 1.8.0'
 
 gem 'rails-html-sanitizer', '~> 1.0.3'
+source "https://gem.fury.io/me/" do
+  gem "stitchfix-env_management", require: "stitch_fix/env_management", group: [:development, :test]
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://gem.fury.io/me/
   specs:
     actionmailer (4.2.10)
       actionpack (= 4.2.10)
@@ -632,6 +633,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    stitchfix-env_management (0.4.0)
+      dotenv-rails
     teaspoon (1.1.5)
       railties (>= 3.2.5, < 6)
     teaspoon-jasmine (2.3.4)
@@ -664,7 +667,6 @@ DEPENDENCIES
   cron2english
   dalli
   dogstatsd-ruby
-  dotenv-rails
   foreman
   jbuilder
   jquery-rails
@@ -686,6 +688,7 @@ DEPENDENCIES
   sass-rails
   selenium-webdriver
   spring
+  stitchfix-env_management!
   teaspoon-jasmine
   uglifier
 


### PR DESCRIPTION
## Problem

We would like to switch to a pattern where we check-in `.env.development` and `.env.test` files and start using `.env.*.local` files for local overrides.

This change will require engineers migrate their local ENV vars.  To help facilitate this change, we created a gem called `env_management`.

## Solution

This PR replaces the `dotenv-rails` gem with `stitchfix-env_management` (which has a dependency of `dotenv-rails`).  Once replaced, engineers can begin using `env_management` to migrate their local envs by running `bundle exec migrate_local_env`

Additionally, if the repo does not already list `.env.development.local` and `.env.test.local` in .gitignore, this PR will add them.

# WARNING BEFORE MERGE

This PR stops `dotenv-rails` from being loaded in production.  This PR is fine to merge UNLESS your app wrongfully has checked-in a `.env` file to load ENV vars in production.

If this app DOES have a checked-in `.env`, DO NOT MERGE THIS PR and notify #eng.

__________

[ ] This app does not have a checked-in `.env` file.
        